### PR TITLE
bump faraday version

### DIFF
--- a/freegeoip.gemspec
+++ b/freegeoip.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = FreeGeoIP::VERSION
   
-  gem.add_runtime_dependency("faraday", "~> 0.8.0")
+  gem.add_runtime_dependency("faraday", "~> 0.9.0")
   gem.add_runtime_dependency("multi_json", "~> 1.2")
   gem.add_development_dependency("rspec", "~> 2.9.0")
   gem.add_development_dependency("vcr", "~> 2.0.0")


### PR DESCRIPTION
`google-api-client` (a dependency of `fog-google`) requires Faraday >= 0.9